### PR TITLE
Fix the permalink

### DIFF
--- a/project-onboarding.md
+++ b/project-onboarding.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Mac Admins Open Source
+permalink: /project-onboarding/
 ---
 
 # Mac Admins Open Source Project Onboarding


### PR DESCRIPTION
Apparently this is required to not make github pages require `.html` at the end of links.